### PR TITLE
Add Mathematical layout to list of layouts, and formatted kotlin

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyMATHv1.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/ThumbKeyMATHv1.kt
@@ -3,8 +3,6 @@ package com.dessalines.thumbkey.keyboards
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.ArrowDropUp
-import androidx.compose.material.icons.outlined.Copyright
-import androidx.compose.material.icons.outlined.KeyboardCapslock
 import com.dessalines.thumbkey.utils.ColorVariant
 import com.dessalines.thumbkey.utils.FontSizeVariant
 import com.dessalines.thumbkey.utils.KeyAction
@@ -437,8 +435,7 @@ val THUMBKEY_MATH_V1_SLASH = KeyboardC(
                     color = ColorVariant.PRIMARY,
                 ),
                 swipeType = SwipeNWay.TWO_WAY_HORIZONTAL,
-                swipes = mapOf(
-                ),
+                swipes = mapOf(),
             ),
             KeyItemC(
                 center = KeyC(
@@ -511,8 +508,7 @@ val THUMBKEY_MATH_V1_SLASH = KeyboardC(
                     size = FontSizeVariant.LARGE,
                     color = ColorVariant.PRIMARY,
                 ),
-                swipes = mapOf(
-                ),
+                swipes = mapOf(),
             ),
             KeyItemC(
                 center = KeyC(

--- a/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/KeyboardLayout.kt
@@ -51,6 +51,7 @@ import com.dessalines.thumbkey.keyboards.THUMBKEY_JA_V1_KATAKANA_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_KA_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_LT_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_LV_LTG_V1_KEYBOARD_MODES
+import com.dessalines.thumbkey.keyboards.THUMBKEY_MATH_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_NL_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_NO_V1_KEYBOARD_MODES
 import com.dessalines.thumbkey.keyboards.THUMBKEY_PL_V2_KEYBOARD_MODES
@@ -143,4 +144,5 @@ enum class KeyboardLayout(val title: String, val index: Int, val modes: Map<Keyb
     MessageEaseUKRUSymbols("MessageEase український-русский with Symbols", 67, MESSAGEEASE_UA_RU_SYMBOLS_KEYBOARD_MODES),
     MessageEaseDESymbols("MessageEase deutsch with Symbols", 68, MESSAGEEASE_DE_SYMBOLS_KEYBOARD_MODES),
     ThumbKeyCAv1("Thumb-Key Canadian Aboriginal Syllabic v1", 69, THUMBKEY_CA_V1_KEYBOARD_MODES),
+    ThumbKeyMATHv1("Thumb-Key Mathematical", 70, THUMBKEY_MATH_V1_KEYBOARD_MODES),
 }


### PR DESCRIPTION
Now you can enable the layout in the settings and switch to it using the layout switcher which is the left swipe on the emoji key :smile: 

This will now pass the lint check which failed. It failed because the layout file was not formatted properly. You can format it yourself. If you're on Linux, you can cd to the directory and run "./gradlew formatKotlin". Alternatively you can run a gradle task in android studio by clicking the gradle toggle on the right hand side, then in the gradle sidebar, you can click the icon of a terminal which says "execute gradle task" then type "gradlew formatKotlin".
If you can't do that and the lint check fails again, just contact me and I'll do it for you :).
